### PR TITLE
fix: `tmpo stats` now lists projects in the same order every time

### DIFF
--- a/cmd/stats.go
+++ b/cmd/stats.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"time"
 
 	"github.com/DylanDevelops/tmpo/internal/storage"
@@ -121,7 +122,16 @@ func ShowPeriodStats(entries []*storage.TimeEntry, periodName string) {
 
 	fmt.Println()
 	ui.PrintInfo(4, ui.Bold("By Project"), "")
-	for project, duration := range projectStats {
+
+	// Sort projects alphabetically for consistent display order
+	var projects []string
+	for project := range projectStats {
+		projects = append(projects, project)
+	}
+	sort.Strings(projects)
+
+	for _, project := range projects {
+		duration := projectStats[project]
 		percentage := (duration.Seconds() / totalDuration.Seconds()) * 100
 		fmt.Printf("        %s  %s  (%.1f%%)\n", ui.Bold(fmt.Sprintf("%-20s", project)), ui.FormatDuration(duration), percentage)
 
@@ -174,12 +184,12 @@ func ShowAllTimeStats(entries []*storage.TimeEntry, db *storage.Database) {
 		}
 	}
 
-	projects, _ := db.GetAllProjects()
+	allProjects, _ := db.GetAllProjects()
 
 	ui.PrintSuccess(ui.EmojiStats, ui.Bold("All-Time Statistics"))
 	ui.PrintInfo(4, ui.Bold("Total Time"), fmt.Sprintf("%s (%.2f hours)", ui.FormatDuration(totalDuration), totalDuration.Hours()))
 	ui.PrintInfo(4, ui.Bold("Total Entries"), fmt.Sprintf("%d", len(entries)))
-	ui.PrintInfo(4, ui.Bold("Projects Tracked"), fmt.Sprintf("%d", len(projects)))
+	ui.PrintInfo(4, ui.Bold("Projects Tracked"), fmt.Sprintf("%d", len(allProjects)))
 
 	if hasAnyEarnings {
 		ui.PrintInfo(4, ui.Bold("Earnings"), fmt.Sprintf("$%.2f", totalEarnings))
@@ -187,7 +197,16 @@ func ShowAllTimeStats(entries []*storage.TimeEntry, db *storage.Database) {
 
 	fmt.Println()
 	ui.PrintInfo(4, ui.Bold("By Project"), "")
-	for project, duration := range projectStats {
+
+	// Sort projects alphabetically for consistent display order
+	var projects []string
+	for project := range projectStats {
+		projects = append(projects, project)
+	}
+	sort.Strings(projects)
+
+	for _, project := range projects {
+		duration := projectStats[project]
 		percentage := (duration.Seconds() / totalDuration.Seconds()) * 100
 		fmt.Printf("        %s  %s  (%.1f%%)\n", ui.Bold(fmt.Sprintf("%-20s", project)), ui.FormatDuration(duration), percentage)
 


### PR DESCRIPTION
Updated the stats display to sort projects alphabetically in both period and all-time statistics for consistent and predictable output. This improves readability and makes it easier to locate specific projects in the stats.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request improves the consistency and readability of project statistics output in the `cmd/stats.go` file by ensuring that project listings are displayed in alphabetical order. This affects both the period-based and all-time statistics views.

**Display improvements:**

* Project statistics in both `ShowPeriodStats` and `ShowAllTimeStats` are now sorted alphabetically for a consistent and predictable display order. [[1]](diffhunk://#diff-fac57bffaaff7a817f0e2324e687502eff4ee3227ccf83f4a49f673573978c22L124-R134) [[2]](diffhunk://#diff-fac57bffaaff7a817f0e2324e687502eff4ee3227ccf83f4a49f673573978c22L177-R209)
* Updated variable naming in `ShowAllTimeStats` for clarity and consistency (`projects` → `allProjects`).

**Dependency update:**

* Added the `"sort"` package import to support alphabetical sorting of project names.
