### PR TITLE
feat: Add `tmpo pause` and `tmpo resume` commands for time tracking

### DIFF
--- a/cmd/pause.go
+++ b/cmd/pause.go
@@ -1,0 +1,58 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/DylanDevelops/tmpo/internal/storage"
+	"github.com/DylanDevelops/tmpo/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var pauseCmd = &cobra.Command{
+	Use:   "pause",
+	Short: "Pause time tracking",
+	Long:  `Pause the currently running time tracking session. Use 'tmpo resume' to continue tracking.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ui.NewlineAbove()
+
+		db, err := storage.Initialize()
+		if err != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		defer db.Close()
+
+		running, err := db.GetRunningEntry()
+		if err != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		if running == nil {
+			ui.PrintWarning(ui.EmojiWarning, "No active time tracking session to pause.")
+			ui.NewlineBelow()
+			os.Exit(0)
+		}
+
+		err = db.StopEntry(running.ID)
+		if(err != nil) {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		duration := time.Since(running.StartTime)
+
+		ui.PrintSuccess(ui.EmojiStop, fmt.Sprintf("Paused tracking %s", ui.Bold(running.ProjectName)))
+		ui.PrintInfo(4, ui.Bold("Session Duration"), ui.FormatDuration(duration))
+		ui.PrintMuted(4, "Use 'tmpo resume' to continue tracking")
+
+		ui.NewlineBelow()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(pauseCmd)
+}

--- a/cmd/resume.go
+++ b/cmd/resume.go
@@ -1,0 +1,71 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/DylanDevelops/tmpo/internal/storage"
+	"github.com/DylanDevelops/tmpo/internal/ui"
+	"github.com/spf13/cobra"
+)
+
+var resumeCmd = &cobra.Command{
+	Use:   "resume",
+	Short: "Resume time tracking",
+	Long:  `Resume time tracking by starting a new session with the same project and description as the last paused session.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		ui.NewlineAbove()
+
+		db, err := storage.Initialize()
+		if err != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		defer db.Close()
+
+		running, err := db.GetRunningEntry()
+		if err != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		if running != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("Already tracking time for `%s`", running.ProjectName))
+			ui.PrintMuted(0, "Use 'tmpo stop' to stop the current session first.")
+			ui.NewlineBelow()
+			os.Exit(1)
+		}
+
+		lastStopped, err := db.GetLastStoppedEntry()
+		if err != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		if lastStopped == nil {
+			ui.PrintError(ui.EmojiError, "No previous session found to resume.")
+			ui.PrintMuted(0, "Use 'tmpo start' to begin a new session.")
+			ui.NewlineBelow()
+			os.Exit(1)
+		}
+
+		entry, err := db.CreateEntry(lastStopped.ProjectName, lastStopped.Description, lastStopped.HourlyRate)
+		if err != nil {
+			ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+			os.Exit(1)
+		}
+
+		ui.PrintSuccess(ui.EmojiStart, fmt.Sprintf("Resumed tracking time for %s", ui.Bold(entry.ProjectName)))
+
+		if entry.Description != "" {
+			ui.PrintInfo(4, "Description", entry.Description)
+		}
+
+		ui.NewlineBelow()
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(resumeCmd)
+}

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,6 +27,41 @@ Stop the currently running time entry.
 tmpo stop
 ```
 
+### `tmpo pause`
+
+Pause the currently running time entry. This is useful for taking quick breaks without losing context. The paused session can be resumed with `tmpo resume`.
+
+```bash
+tmpo pause
+# Output:
+# [tmpo] Paused tracking my-project
+#     Session Duration: 45m 23s
+#     Use 'tmpo resume' to continue tracking
+```
+
+**How it works:**
+
+- Stops the current time entry (records end time)
+- Use `tmpo resume` to start a new entry with the same project and description
+- Each pause creates a separate time entry, giving you a detailed audit trail
+
+### `tmpo resume`
+
+Resume time tracking by starting a new session with the same project and description as the last paused (or stopped) session.
+
+```bash
+tmpo resume
+# Output:
+# [tmpo] Resumed tracking time for my-project
+#     Description: Implementing feature
+```
+
+**Use cases:**
+
+- Continue work after a break
+- Resume after accidentally stopping the timer
+- Quickly restart the same task
+
 ### `tmpo status`
 
 View the current tracking session with elapsed time.
@@ -102,6 +137,7 @@ tmpo init --accept-defaults   # Creates .tmporc with defaults, no prompts
 ```
 
 This creates a `.tmporc` file with:
+
 - Project name from Git repo or directory name
 - Hourly rate of 0 (disabled)
 - Empty description
@@ -233,6 +269,22 @@ my-project,Implementing feature,2024-01-15 14:30:00,2024-01-15 16:45:00,2.25
 ```
 
 ## Tips and Workflows
+
+### Taking Breaks with Pause/Resume
+
+Use pause and resume for quick breaks without losing context:
+
+```bash
+tmpo start "Implementing authentication"
+# ... work for a while ...
+tmpo pause    # Take a lunch break
+# ... break time ...
+tmpo resume   # Continue same task
+# ... more work ...
+tmpo stop     # Done for the day
+```
+
+This creates separate entries for each work session, making it easy to see your actual working time versus break time when reviewing your log.
 
 ### Quick Daily Review
 


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #21

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request introduces pause and resume functionality to the time tracking CLI, allowing users to temporarily stop and later continue tracking their work without losing context. It adds new commands, updates documentation, and enhances the database layer to support resuming the most recent session. The most important changes are:

**New CLI Commands:**
- Added `pause` command (`cmd/pause.go`) to stop the current time entry, display session duration, and instruct the user to use `resume` to continue tracking.
- Added `resume` command (`cmd/resume.go`) to start a new time entry with the same project and description as the last stopped session, with appropriate user feedback and error handling.

**Database Enhancements:**
- Implemented `GetLastStoppedEntry` in `internal/storage/db.go` to retrieve the most recently stopped (non-running) time entry, supporting the resume feature.
- Added comprehensive tests for `GetLastStoppedEntry` to ensure correct behavior under various conditions.

**Documentation Updates:**
- Expanded `docs/usage.md` with sections on using `pause` and `resume`, including examples, workflow tips, and explanations of how the features work. [[1]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R30-R64) [[2]](diffhunk://#diff-72376d0b487d7231cf31959bf266f6aea098e899743bae02e36d176cef4db476R273-R288)
- Minor formatting and clarity improvements in documentation.

## Screenshots

<!--
If this PR touches the visual layer of tmpo, please include screenshots or animated gifs to show the changes.
-->

<img width="314" height="169" alt="Screenshot 2025-12-18 at 11 48 05 PM" src="https://github.com/user-attachments/assets/44905d9f-a09c-487c-a34a-f4d820d41ff0" />
