### PR TITLE
fix: Changes are no longer detected when start and end time are left empty in `tmpo edit`

### DIFF
--- a/cmd/entries/edit.go
+++ b/cmd/entries/edit.go
@@ -259,7 +259,6 @@ func EditCmd() *cobra.Command {
 
 			hasChanges := false
 
-			// Truncate to minute precision for comparison since parseDateTime only parses to the minute
 			selectedStartTrunc := selectedEntry.StartTime.Truncate(time.Minute)
 			editedStartTrunc := editedEntry.StartTime.Truncate(time.Minute)
 


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #31

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request improves the accuracy of change detection in the entry editing command by ensuring time comparisons only consider minute-level precision. This prevents false positives when comparing timestamps that may have different second or sub-second values but are otherwise equivalent at the minute level.

Key changes:

Time comparison precision:

* Updated the comparison logic in the `EditCmd` command to truncate both the original and edited start and end times to the nearest minute before checking for changes, ensuring only meaningful differences are detected.

Dependency update:

* Added the `time` package import in `cmd/entries/edit.go` to support time truncation operations.
