### PR TITLE
fix: Timezone conversion issues with `tmpo stats` incorrectly missing time entries after time threshold

### DIFF
--- a/cmd/history/stats.go
+++ b/cmd/history/stats.go
@@ -36,7 +36,8 @@ func StatsCmd() *cobra.Command {
 			var periodName string
 
 			if statsToday {
-				start = time.Now().Truncate(24 * time.Hour)
+				now := time.Now()
+				start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
 				end = start.Add(24 * time.Hour)
 				periodName = "Today"
 			} else if statsWeek {
@@ -46,7 +47,7 @@ func StatsCmd() *cobra.Command {
 					weekday = 7
 				}
 
-				start = now.AddDate(0, 0, -weekday+1).Truncate(24 * time.Hour)
+				start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).AddDate(0, 0, -weekday+1)
 				end = start.AddDate(0, 0, 7)
 				periodName = "This Week"
 			} else {


### PR DESCRIPTION
Replaces use of Truncate with time.Date to accurately set the start of the day when calculating stats for today and this week. This ensures correct period boundaries based on the current location.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #32

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes small improvements to the way the start date is calculated for the "today" and "this week" statistics in the `StatsCmd` function. The changes improve clarity and consistency in how the start of the day is determined.

- Changed the calculation of the start of "today" to use `time.Date` for clearer intent and consistency.
- Updated the calculation of the start of "this week" to also use `time.Date`, aligning it with the approach used for "today".