### PR TITLE
refactor: Optional development environment separate from production database for testing purposes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,48 @@ go build -o tmpo .
 ./tmpo --help
 ```
 
+### Development Mode
+
+To prevent corrupting your real tmpo data during development, use the `TMPO_DEV` environment variable:
+
+```bash
+# Enable development mode (uses ~/.tmpo-dev/ instead of ~/.tmpo/)
+export TMPO_DEV=1
+
+# Now all commands use the development database
+./tmpo start "Testing new feature"
+./tmpo status
+./tmpo stop
+```
+
+**Database Locations:**
+
+- **Production mode** (default): `~/.tmpo/tmpo.db`
+- **Development mode** (`TMPO_DEV=1`): `~/.tmpo-dev/tmpo.db`
+
+> [!NOTE]
+> The `export TMPO_DEV=1` command only applies to your **current terminal session**. When you close the terminal, it resets to production mode. This is intentional for safety - you must explicitly enable dev mode each time.
+
+**Making it persistent (optional):**
+
+If you prefer to always use dev mode, add it to your shell profile:
+
+```bash
+# For zsh (macOS default)
+echo 'export TMPO_DEV=1' >> ~/.zshrc
+
+# For bash
+echo 'export TMPO_DEV=1' >> ~/.bashrc
+```
+
+Then restart your terminal or run `source ~/.zshrc` (or `source ~/.bashrc`).
+
+**Benefits of development mode:**
+
+- Your real time tracking data stays safe
+- You can test database changes without risk
+- You can easily clean up test data (`rm -rf ~/.tmpo-dev/`)
+
 ### Building with Version Information
 
 To build with version information injected (useful for testing version display):
@@ -120,15 +162,21 @@ tmpo/
 All user data is stored locally in:
 
 ```
-~/.tmpo/
-  └── tmpo.db          # SQLite database
+~/.tmpo/              # Production (default)
+  └── tmpo.db
+
+~/.tmpo-dev/          # Development (when TMPO_DEV=1)
+  └── tmpo.db
 ```
 
 The database schema includes:
 
-- Time entries (start/end times, project, description)
+- Time entries (start/end times, project, description, hourly rate)
 - Project metadata (derived from entries)
 - Automatic indexing for fast queries
+
+> [!NOTE]
+> See [Development Mode](#development-mode) for information on using the development database during local development.
 
 ### How Project Detection Works
 


### PR DESCRIPTION
Introduces a development mode activated by the TMPO_DEV environment variable, which uses a separate database directory (~/.tmpo-dev/) to prevent accidental modification of production data. Updates documentation to explain usage, benefits, and database locations for both production and development modes.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #36

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request adds a development mode to the application, allowing developers to safely test changes without affecting real user data. It introduces the `TMPO_DEV` environment variable, which switches the database location to a separate directory for development purposes. Documentation has been updated to explain how to use this feature and clarify the differences between production and development modes.

**Development mode support:**

* Added logic in `internal/storage/db.go` to check the `TMPO_DEV` environment variable; when set to `"1"` or `"true"`, the application uses the `~/.tmpo-dev/` directory for its database instead of the default `~/.tmpo/` directory. [[1]](diffhunk://#diff-25c9344eb84d33777216085c6c629dd1aa84d79a76fe2ed323d95fa65dc73503L30-R34) [[2]](diffhunk://#diff-25c9344eb84d33777216085c6c629dd1aa84d79a76fe2ed323d95fa65dc73503R53-R58)

**Documentation updates:**

* Updated `CONTRIBUTING.md` with a new "Development Mode" section, including usage instructions, database locations, and guidance on making the setting persistent for development.
* Clarified the storage locations for production and development databases in the "Database Storage" section of `CONTRIBUTING.md`, and added a reference to the new development mode documentation.