### PR TITLE
feat: Add 30+ currency options for billing and stats display

### DIFF
--- a/cmd/entries/manual.go
+++ b/cmd/entries/manual.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/DylanDevelops/tmpo/internal/config"
+	"github.com/DylanDevelops/tmpo/internal/currency"
 	"github.com/DylanDevelops/tmpo/internal/project"
 	"github.com/DylanDevelops/tmpo/internal/storage"
 	"github.com/DylanDevelops/tmpo/internal/ui"
@@ -167,9 +168,15 @@ func ManualCmd() *cobra.Command {
 			}
 
 			if entry.HourlyRate != nil {
+				// Get currency from config, fallback to USD
+				currencyCode := "USD"
+				if cfg, _, err := config.FindAndLoad(); err == nil {
+					currencyCode = cfg.GetCurrencyOrDefault()
+				}
+
 				earnings := entry.RoundedHours() * *entry.HourlyRate
-				fmt.Printf("    %s %s\n", ui.BoldInfo("Hourly Rate:"), fmt.Sprintf("$%.2f", *entry.HourlyRate))
-				fmt.Printf("    %s %s\n", ui.BoldInfo("Earnings:"), fmt.Sprintf("$%.2f", earnings))
+				fmt.Printf("    %s %s\n", ui.BoldInfo("Hourly Rate:"), currency.FormatCurrency(*entry.HourlyRate, currencyCode))
+				fmt.Printf("    %s %s\n", ui.BoldInfo("Earnings:"), currency.FormatCurrency(earnings, currencyCode))
 			}
 
 			ui.NewlineBelow()

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,6 +30,7 @@ tmpo init
 # - Project name (defaults to auto-detected name)
 # - Hourly rate (optional, press Enter to skip)
 # - Description (optional, press Enter to skip)
+# - Currency code (optional, defaults to USD)
 ```
 
 For quick setup without prompts, use the `--accept-defaults` flag:
@@ -57,6 +58,9 @@ hourly_rate: 125.50
 
 # [OPTIONAL] Description for this project
 description: Client project for Acme Corp
+
+# [OPTIONAL] Currency code for billing display (USD, EUR, GBP, JPY, etc.)
+currency: USD
 ```
 
 ### Configuration Fields
@@ -73,12 +77,13 @@ project_name: Client Website Redesign
 
 #### `hourly_rate` (optional)
 
-Your billing rate in dollars per hour. When set, tmpo will calculate estimated earnings based on tracked time.
+Your billing rate per hour. When set, tmpo will calculate estimated earnings based on tracked time. The currency symbol displayed is determined by the `currency` field (defaults to USD if not specified).
 
 **Example:**
 
 ```yaml
 hourly_rate: 150.00
+currency: USD  # Will display as $150.00
 ```
 
 Set to `0` or omit to disable rate tracking:
@@ -96,6 +101,47 @@ A longer description or notes about the project. This is for your reference and 
 ```yaml
 description: Q1 2024 website redesign for Acme Corp. Main contact: john@acme.com
 ```
+
+#### `currency` (optional)
+
+The ISO 4217 currency code for displaying billing rates and earnings. This determines the currency symbol shown in stats, reports, and summaries.
+
+**Supported Currencies:**
+
+tmpo supports 30+ currencies including:
+
+- **Americas:** USD ($), CAD (CA$), BRL (R$), MXN (MX$)
+- **Europe:** EUR (€), GBP (£), CHF (Fr), SEK (kr), NOK (kr)
+- **Asia:** JPY (¥), CNY (¥), INR (₹), KRW (₩), SGD (S$)
+- **Oceania:** AUD (A$), NZD (NZ$)
+
+And many more. See the [full currency code list](https://en.wikipedia.org/wiki/ISO_4217#Active_codes).
+
+**Examples:**
+
+```yaml
+# US-based project
+hourly_rate: 150
+currency: USD
+# Displays as: $150.00
+
+# European project
+hourly_rate: 120
+currency: EUR
+# Displays as: €120.00
+
+# UK project
+hourly_rate: 100
+currency: GBP
+# Displays as: £100.00
+
+# Japanese project
+hourly_rate: 15000
+currency: JPY
+# Displays as: ¥15000.00
+```
+
+If not specified or if an unknown currency code is provided, `currency` defaults to USD. Currency codes are case-insensitive (USD, usd, or Usd all work).
 
 ## Project Detection Priority
 
@@ -150,13 +196,15 @@ tmpo init
 # Project name: Client A - Web Development
 # Hourly rate: 150
 # Description: [press Enter to skip]
+# Currency code: USD
 
-# Client B - $175/hour
+# Client B - £175/hour
 cd ~/projects/client-b
 tmpo init
 # Project name: Client B - Game Development
 # Hourly rate: 175
 # Description: [press Enter to skip]
+# Currency code: GBP
 
 # Personal project - no billing
 cd ~/projects/my-app
@@ -166,9 +214,11 @@ tmpo init --accept-defaults  # Quick setup with defaults
 Alternatively, you can manually create `.tmporc` files:
 
 ```bash
-cat > ~/projects/client-a/.tmporc << EOF
-project_name: Client A - Web Development
+# Client configuration
+cat > ~/projects/client-project/.tmporc << EOF
+project_name: Client Project - Web Development
 hourly_rate: 150.00
+currency: USD
 EOF
 ```
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -179,7 +179,7 @@ func TestCreateWithTemplate(t *testing.T) {
 		err = os.Chdir(tmpDir)
 		assert.NoError(t, err)
 
-		err = CreateWithTemplate("templated-project", 99.99, "Test description")
+		err = CreateWithTemplate("templated-project", 99.99, "Test description", "EUR")
 		assert.NoError(t, err)
 
 		// Verify file was created
@@ -192,6 +192,7 @@ func TestCreateWithTemplate(t *testing.T) {
 		assert.Contains(t, string(content), "project_name: templated-project")
 		assert.Contains(t, string(content), "hourly_rate: 99.99")
 		assert.Contains(t, string(content), "description: \"Test description\"")
+		assert.Contains(t, string(content), "currency: EUR")
 		assert.Contains(t, string(content), "# [OPTIONAL]")
 
 		// Verify it can be loaded
@@ -200,6 +201,7 @@ func TestCreateWithTemplate(t *testing.T) {
 		assert.Equal(t, "templated-project", cfg.ProjectName)
 		assert.Equal(t, 99.99, cfg.HourlyRate)
 		assert.Equal(t, "Test description", cfg.Description)
+		assert.Equal(t, "EUR", cfg.Currency)
 	})
 
 	t.Run("returns error if file exists", func(t *testing.T) {
@@ -212,11 +214,11 @@ func TestCreateWithTemplate(t *testing.T) {
 		assert.NoError(t, err)
 
 		// Create initial file
-		err = CreateWithTemplate("first", 100.0, "desc")
+		err = CreateWithTemplate("first", 100.0, "desc", "USD")
 		assert.NoError(t, err)
 
 		// Try to create again
-		err = CreateWithTemplate("second", 200.0, "desc2")
+		err = CreateWithTemplate("second", 200.0, "desc2", "EUR")
 		assert.Error(t, err)
 		assert.Contains(t, err.Error(), "already exists")
 	})

--- a/internal/currency/currency.go
+++ b/internal/currency/currency.go
@@ -1,0 +1,114 @@
+package currency
+
+import (
+	"fmt"
+	"strings"
+)
+
+// DefaultCurrency is the currency code used when none is specified in configuration.
+const DefaultCurrency = "USD"
+
+// currencySymbols maps ISO 4217 currency codes to their display symbols.
+// This map includes the most commonly used global currencies.
+var currencySymbols = map[string]string{
+	// Americas
+	"USD": "$",   // United States Dollar
+	"CAD": "CA$", // Canadian Dollar
+	"BRL": "R$",  // Brazilian Real
+	"MXN": "MX$", // Mexican Peso
+	"ARS": "AR$", // Argentine Peso
+
+	// Europe
+	"EUR": "€",   // Euro
+	"GBP": "£",   // British Pound Sterling
+	"CHF": "Fr",  // Swiss Franc
+	"SEK": "kr",  // Swedish Krona
+	"NOK": "kr",  // Norwegian Krone
+	"DKK": "kr",  // Danish Krone
+	"PLN": "zł",  // Polish Zloty
+	"CZK": "Kč",  // Czech Koruna
+
+	// Asia
+	"JPY": "¥",   // Japanese Yen
+	"CNY": "¥",   // Chinese Yuan
+	"INR": "₹",   // Indian Rupee
+	"KRW": "₩",   // South Korean Won
+	"SGD": "S$",  // Singapore Dollar
+	"HKD": "HK$", // Hong Kong Dollar
+	"THB": "฿",   // Thai Baht
+	"IDR": "Rp",  // Indonesian Rupiah
+	"MYR": "RM",  // Malaysian Ringgit
+	"PHP": "₱",   // Philippine Peso
+	"VND": "₫",   // Vietnamese Dong
+
+	// Oceania
+	"AUD": "A$",  // Australian Dollar
+	"NZD": "NZ$", // New Zealand Dollar
+
+	// Middle East & Africa
+	"AED": "د.إ", // UAE Dirham
+	"SAR": "﷼",   // Saudi Riyal
+	"ILS": "₪",   // Israeli Shekel
+	"ZAR": "R",   // South African Rand
+	"EGP": "E£",  // Egyptian Pound
+	"TRY": "₺",   // Turkish Lira
+}
+
+// FormatCurrency formats an amount with the appropriate currency symbol.
+// The currencyCode is normalized to uppercase and looked up in the symbol map.
+// If the currency code is empty or unknown, it defaults to USD ($).
+//
+// Examples:
+//   FormatCurrency(150.00, "USD") returns "$150.00"
+//   FormatCurrency(99.99, "EUR") returns "€99.99"
+//   FormatCurrency(1234.56, "GBP") returns "£1234.56"
+//   FormatCurrency(100.00, "") returns "$100.00"
+//   FormatCurrency(100.00, "UNKNOWN") returns "$100.00"
+func FormatCurrency(amount float64, currencyCode string) string {
+	// Normalize currency code to uppercase
+	currencyCode = strings.ToUpper(strings.TrimSpace(currencyCode))
+
+	// Default to USD if empty or unknown
+	if currencyCode == "" || !IsSupported(currencyCode) {
+		currencyCode = DefaultCurrency
+	}
+
+	symbol := GetSymbol(currencyCode)
+	return fmt.Sprintf("%s%.2f", symbol, amount)
+}
+
+// GetSymbol returns the display symbol for the given currency code.
+// The currency code is normalized to uppercase before lookup.
+// If the currency code is not found, it returns the code itself.
+//
+// Examples:
+//   GetSymbol("USD") returns "$"
+//   GetSymbol("eur") returns "€"
+//   GetSymbol("UNKNOWN") returns "UNKNOWN"
+func GetSymbol(currencyCode string) string {
+	currencyCode = strings.ToUpper(strings.TrimSpace(currencyCode))
+
+	if symbol, exists := currencySymbols[currencyCode]; exists {
+		return symbol
+	}
+
+	return currencyCode
+}
+
+// IsSupported returns true if the given currency code is in the supported currencies map.
+// The currency code is normalized to uppercase before checking.
+func IsSupported(currencyCode string) bool {
+	currencyCode = strings.ToUpper(strings.TrimSpace(currencyCode))
+	_, exists := currencySymbols[currencyCode]
+	return exists
+}
+
+// GetSupportedCurrencies returns a sorted list of all supported currency codes.
+// This is useful for documentation or validation purposes.
+func GetSupportedCurrencies() []string {
+	currencies := make([]string, 0, len(currencySymbols))
+	for code := range currencySymbols {
+		currencies = append(currencies, code)
+	}
+	return currencies
+}

--- a/internal/currency/currency_test.go
+++ b/internal/currency/currency_test.go
@@ -1,0 +1,309 @@
+package currency
+
+import (
+	"testing"
+)
+
+func TestFormatCurrency(t *testing.T) {
+	tests := []struct {
+		name         string
+		amount       float64
+		currencyCode string
+		expected     string
+	}{
+		// USD tests
+		{
+			name:         "USD with standard amount",
+			amount:       150.00,
+			currencyCode: "USD",
+			expected:     "$150.00",
+		},
+		{
+			name:         "USD with decimal places",
+			amount:       99.99,
+			currencyCode: "USD",
+			expected:     "$99.99",
+		},
+		{
+			name:         "USD with zero",
+			amount:       0.00,
+			currencyCode: "USD",
+			expected:     "$0.00",
+		},
+		{
+			name:         "USD with large amount",
+			amount:       123456.78,
+			currencyCode: "USD",
+			expected:     "$123456.78",
+		},
+
+		// Euro tests
+		{
+			name:         "EUR with standard amount",
+			amount:       100.00,
+			currencyCode: "EUR",
+			expected:     "€100.00",
+		},
+		{
+			name:         "EUR lowercase",
+			amount:       50.50,
+			currencyCode: "eur",
+			expected:     "€50.50",
+		},
+
+		// GBP tests
+		{
+			name:         "GBP with standard amount",
+			amount:       200.00,
+			currencyCode: "GBP",
+			expected:     "£200.00",
+		},
+
+		// Asian currencies
+		{
+			name:         "JPY with standard amount",
+			amount:       10000.00,
+			currencyCode: "JPY",
+			expected:     "¥10000.00",
+		},
+		{
+			name:         "INR with standard amount",
+			amount:       5000.00,
+			currencyCode: "INR",
+			expected:     "₹5000.00",
+		},
+		{
+			name:         "KRW with standard amount",
+			amount:       100000.00,
+			currencyCode: "KRW",
+			expected:     "₩100000.00",
+		},
+
+		// Other currencies
+		{
+			name:         "CAD with standard amount",
+			amount:       75.00,
+			currencyCode: "CAD",
+			expected:     "CA$75.00",
+		},
+		{
+			name:         "AUD with standard amount",
+			amount:       150.00,
+			currencyCode: "AUD",
+			expected:     "A$150.00",
+		},
+		{
+			name:         "CHF with standard amount",
+			amount:       100.00,
+			currencyCode: "CHF",
+			expected:     "Fr100.00",
+		},
+
+		// Edge cases
+		{
+			name:         "Empty currency code defaults to USD",
+			amount:       100.00,
+			currencyCode: "",
+			expected:     "$100.00",
+		},
+		{
+			name:         "Unknown currency code defaults to USD",
+			amount:       100.00,
+			currencyCode: "XYZ",
+			expected:     "$100.00",
+		},
+		{
+			name:         "Whitespace in currency code",
+			amount:       50.00,
+			currencyCode: "  USD  ",
+			expected:     "$50.00",
+		},
+		{
+			name:         "Mixed case currency code",
+			amount:       75.25,
+			currencyCode: "GbP",
+			expected:     "£75.25",
+		},
+		{
+			name:         "Very small amount",
+			amount:       0.01,
+			currencyCode: "USD",
+			expected:     "$0.01",
+		},
+		{
+			name:         "Amount with many decimal places (should round to 2)",
+			amount:       99.999,
+			currencyCode: "USD",
+			expected:     "$100.00",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatCurrency(tt.amount, tt.currencyCode)
+			if result != tt.expected {
+				t.Errorf("FormatCurrency(%f, %q) = %q, expected %q",
+					tt.amount, tt.currencyCode, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetSymbol(t *testing.T) {
+	tests := []struct {
+		name         string
+		currencyCode string
+		expected     string
+	}{
+		{
+			name:         "USD returns dollar sign",
+			currencyCode: "USD",
+			expected:     "$",
+		},
+		{
+			name:         "EUR returns euro sign",
+			currencyCode: "EUR",
+			expected:     "€",
+		},
+		{
+			name:         "GBP returns pound sign",
+			currencyCode: "GBP",
+			expected:     "£",
+		},
+		{
+			name:         "JPY returns yen sign",
+			currencyCode: "JPY",
+			expected:     "¥",
+		},
+		{
+			name:         "Lowercase currency code",
+			currencyCode: "usd",
+			expected:     "$",
+		},
+		{
+			name:         "Mixed case currency code",
+			currencyCode: "Eur",
+			expected:     "€",
+		},
+		{
+			name:         "Unknown currency returns code itself",
+			currencyCode: "XYZ",
+			expected:     "XYZ",
+		},
+		{
+			name:         "Whitespace is trimmed",
+			currencyCode: "  GBP  ",
+			expected:     "£",
+		},
+		{
+			name:         "Empty string returns empty",
+			currencyCode: "",
+			expected:     "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := GetSymbol(tt.currencyCode)
+			if result != tt.expected {
+				t.Errorf("GetSymbol(%q) = %q, expected %q",
+					tt.currencyCode, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsSupported(t *testing.T) {
+	tests := []struct {
+		name         string
+		currencyCode string
+		expected     bool
+	}{
+		{
+			name:         "USD is supported",
+			currencyCode: "USD",
+			expected:     true,
+		},
+		{
+			name:         "EUR is supported",
+			currencyCode: "EUR",
+			expected:     true,
+		},
+		{
+			name:         "GBP is supported",
+			currencyCode: "GBP",
+			expected:     true,
+		},
+		{
+			name:         "JPY is supported",
+			currencyCode: "JPY",
+			expected:     true,
+		},
+		{
+			name:         "INR is supported",
+			currencyCode: "INR",
+			expected:     true,
+		},
+		{
+			name:         "Lowercase USD is supported",
+			currencyCode: "usd",
+			expected:     true,
+		},
+		{
+			name:         "Unknown currency is not supported",
+			currencyCode: "XYZ",
+			expected:     false,
+		},
+		{
+			name:         "Empty string is not supported",
+			currencyCode: "",
+			expected:     false,
+		},
+		{
+			name:         "Whitespace around supported code",
+			currencyCode: "  EUR  ",
+			expected:     true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsSupported(tt.currencyCode)
+			if result != tt.expected {
+				t.Errorf("IsSupported(%q) = %v, expected %v",
+					tt.currencyCode, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestGetSupportedCurrencies(t *testing.T) {
+	currencies := GetSupportedCurrencies()
+
+	// Check that we have a reasonable number of currencies
+	if len(currencies) < 20 {
+		t.Errorf("GetSupportedCurrencies() returned %d currencies, expected at least 20",
+			len(currencies))
+	}
+
+	// Check that common currencies are included
+	commonCurrencies := []string{"USD", "EUR", "GBP", "JPY", "CNY", "INR", "CAD", "AUD"}
+	for _, code := range commonCurrencies {
+		found := false
+		for _, c := range currencies {
+			if c == code {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("GetSupportedCurrencies() missing expected currency: %s", code)
+		}
+	}
+}
+
+func TestDefaultCurrency(t *testing.T) {
+	if DefaultCurrency != "USD" {
+		t.Errorf("DefaultCurrency = %q, expected %q", DefaultCurrency, "USD")
+	}
+}


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #34

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request adds support for customizable currency codes in project configuration, allowing users to specify the currency symbol used for billing rates and earnings. The changes affect project setup, display of earnings and hourly rates, configuration file structure, and documentation. The most important updates are grouped below.

**Feature: Currency Code Support**

* Added a `currency` field to the project configuration (`Config` struct and `.tmporc` files) to allow users to specify an ISO 4217 currency code for billing display (e.g., USD, EUR, GBP). If not set, it defaults to USD. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR18-R25) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR49-R51) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR158-R166)
* Updated the project initialization flow (`tmpo init`) to prompt for currency code, validate input, and store it in the config. The display of hourly rate and earnings now uses the selected currency symbol. [[1]](diffhunk://#diff-b0c6fff3ba7d11e1a04fc180c4610f3f2e36d9289e8ff91e261f9280e628a11eR41-R48) [[2]](diffhunk://#diff-b0c6fff3ba7d11e1a04fc180c4610f3f2e36d9289e8ff91e261f9280e628a11eR104-R124) [[3]](diffhunk://#diff-b0c6fff3ba7d11e1a04fc180c4610f3f2e36d9289e8ff91e261f9280e628a11eL113-R140) [[4]](diffhunk://#diff-b0c6fff3ba7d11e1a04fc180c4610f3f2e36d9289e8ff91e261f9280e628a11eR194-R215)
* All locations where earnings or rates are shown (manual entry, stats, etc.) now format amounts using the configured currency code. [[1]](diffhunk://#diff-e21132e0c6f46fa50f48c63ba574d5bf722a683b749f1027e9b5081c4f6b66cfR171-R179) [[2]](diffhunk://#diff-3204a7025c953533e8c79d17194a7ce0d9f95a9b8448ac523520704bfbf04f8dR124-R132) [[3]](diffhunk://#diff-3204a7025c953533e8c79d17194a7ce0d9f95a9b8448ac523520704bfbf04f8dL147-R151) [[4]](diffhunk://#diff-3204a7025c953533e8c79d17194a7ce0d9f95a9b8448ac523520704bfbf04f8dR200-R208) [[5]](diffhunk://#diff-3204a7025c953533e8c79d17194a7ce0d9f95a9b8448ac523520704bfbf04f8dL222-R243)

**Configuration and API Changes**

* Updated the configuration template, loading, and creation logic to handle the new `currency` field, including a helper method to get the currency or default to USD. [[1]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR35) [[2]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdL102-R115) [[3]](diffhunk://#diff-54c7c1af5fa8d5db4dc49f0e8e80e93ba2b1183ba4d5c9e2e5729e6deae6a3cdR158-R166)
* Modified tests to cover the new currency field in configuration creation and loading. [[1]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L182-R182) [[2]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R195) [[3]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62R204) [[4]](diffhunk://#diff-78b78dc33eda1ed8d509bfa5a00f66709af57bd30d971cbaec454571a91c3e62L215-R221)

**Documentation Updates**

* Expanded documentation to describe the new `currency` field, provide examples for multiple currencies, and update setup instructions to reflect currency support. [[1]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R33) [[2]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R61-R63) [[3]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L76-R86) [[4]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R105-R145) [[5]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180R199-R207) [[6]](diffhunk://#diff-17ed18489a956f326ec0fe4040850c5bc9261d4631fb42da4c52891d74a59180L169-R221)