### PR TITLE
fix: More user friendly error messages on creation of milestones

### DIFF
--- a/cmd/milestones/start.go
+++ b/cmd/milestones/start.go
@@ -48,10 +48,28 @@ func StartCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			// check if this name is already in use currently or in the past
+			existingMilestone, err := db.GetMilestoneByName(projectName, milestoneName)
+			if err != nil {
+				ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+				os.Exit(1)
+			}
+
+			if existingMilestone != nil {
+				ui.PrintError(ui.EmojiError, fmt.Sprintf("Milestone '%s' already exists for %s", milestoneName, projectName))
+				if existingMilestone.IsActive() {
+					ui.PrintMuted(0, "This milestone is currently active. Use a different name or finish it first.")
+				} else {
+					ui.PrintMuted(0, "This milestone has already been finished. Use a different name for the new milestone.")
+				}
+				ui.NewlineBelow()
+				os.Exit(1)
+			}
+
 			// Create the milestone
 			milestone, err := db.CreateMilestone(projectName, milestoneName)
 			if err != nil {
-				ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
+				ui.PrintError(ui.EmojiError, fmt.Sprintf("failed to create milestone: %v", err))
 				os.Exit(1)
 			}
 


### PR DESCRIPTION
Adds a check to ensure milestone names are unique within a project, blocking creation if the name is already used for an active or finished milestone. Improves error messaging for failed milestone creation.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request adds a validation step to the milestone creation command to prevent duplicate milestone names, improving data integrity and user experience. Now, if a milestone name has already been used (either for an active or finished milestone), the command will display a clear error message and exit, guiding the user on how to proceed.

Milestone name validation:

* Added a check in `cmd/milestones/start.go` to ensure that a milestone name is not reused for the same project, whether the milestone is currently active or has been finished in the past. Displays specific error messages based on milestone status and prevents creation if a conflict is found.

## Screenshots

<!--
If this PR touches the visual layer of tmpo, please include screenshots or animated gifs to show the changes.
-->

<img width="644" height="34" alt="Screenshot 2025-12-30 at 6 10 24 PM" src="https://github.com/user-attachments/assets/3cb7c4f4-8419-488b-8b45-b3ed08328535" />
<img width="579" height="35" alt="Screenshot 2025-12-30 at 6 10 34 PM" src="https://github.com/user-attachments/assets/b9c642f8-bd9e-46f8-a629-d3ed363d029e" />
