### PR TITLE
fix: `tmpo pause` and `tmpo resume` now includes milestone context

### DIFF
--- a/cmd/tracking/resume.go
+++ b/cmd/tracking/resume.go
@@ -51,7 +51,7 @@ func ResumeCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
-			entry, err := db.CreateEntry(lastStopped.ProjectName, lastStopped.Description, lastStopped.HourlyRate, nil)
+			entry, err := db.CreateEntry(lastStopped.ProjectName, lastStopped.Description, lastStopped.HourlyRate, lastStopped.MilestoneName)
 			if err != nil {
 				ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
 				os.Exit(1)
@@ -61,6 +61,10 @@ func ResumeCmd() *cobra.Command {
 
 			if entry.Description != "" {
 				ui.PrintInfo(4, "Description", entry.Description)
+			}
+
+			if entry.MilestoneName != nil {
+				ui.PrintInfo(4, "Milestone", *entry.MilestoneName)
 			}
 
 			ui.NewlineBelow()


### PR DESCRIPTION
The resume command now passes the milestone name when creating a new entry and displays the milestone if present. This improves tracking of resumed tasks associated with specific milestones.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #55

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes improvements to the resume command in the time tracking CLI by ensuring milestone information is correctly handled and displayed when resuming a stopped entry. The changes ensure that if a milestone was associated with the last stopped entry, it is now passed to the database and shown to the user.

Enhancements to milestone handling in resume command:

* Passes the `MilestoneName` from the last stopped entry to the `db.CreateEntry` function, ensuring that milestone data is preserved when resuming an entry.
* Adds logic to display the milestone name in the UI output if the resumed entry includes a milestone, improving user feedback.
