### PR TITLE
refactor: "Keep Current" is not first option in `tmpo config` for easier step through

### DIFF
--- a/cmd/config/config.go
+++ b/cmd/config/config.go
@@ -79,7 +79,7 @@ func ConfigCmd() *cobra.Command {
 
 			// Date format selection
 			fmt.Println()
-			dateFormatOptions := []string{"MM/DD/YYYY", "DD/MM/YYYY", "YYYY-MM-DD", "Keep current"}
+			dateFormatOptions := []string{"Keep current", "MM/DD/YYYY", "DD/MM/YYYY", "YYYY-MM-DD"}
 			dateFormatSelect := promptui.Select{
 				Label: "Select date format",
 				Items: dateFormatOptions,
@@ -98,7 +98,7 @@ func ConfigCmd() *cobra.Command {
 
 			// Time format selection
 			fmt.Println()
-			timeFormatOptions := []string{"24-hour", "12-hour (AM/PM)", "Keep current"}
+			timeFormatOptions := []string{"Keep current", "24-hour", "12-hour (AM/PM)"}
 			timeFormatSelect := promptui.Select{
 				Label: "Select time format",
 				Items: timeFormatOptions,


### PR DESCRIPTION
Moved the 'Keep current' option to the top of both date and time format selection lists for improved user experience in the config command.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes small improvements to the user experience in the configuration command by reordering the options for date and time format selection. The "Keep current" option is now listed first in both selectors, making it more convenient for users who do not wish to change their current settings.

- User experience improvements:
  * Changed the order of `dateFormatOptions` in `cmd/config/config.go` so that "Keep current" appears first in the date format selection prompt.
  * Changed the order of `timeFormatOptions` in `cmd/config/config.go` so that "Keep current" appears first in the time format selection prompt.
