### PR TITLE
fix: Active milestone included in `tmpo status`

### DIFF
--- a/cmd/tracking/status.go
+++ b/cmd/tracking/status.go
@@ -52,6 +52,10 @@ func StatusCmd() *cobra.Command {
 				ui.PrintInfo(4, ui.Bold("Description"), running.Description)
 			}
 
+			if *running.MilestoneName != "" {
+				ui.PrintInfo(4, ui.Bold("Milestone"), *running.MilestoneName);
+			}
+
 			ui.NewlineBelow()
 		},
 	}


### PR DESCRIPTION
Adds display of the milestone name in the tracking status command output if it is set.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #64

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request adds an enhancement to the `status` command output by displaying the milestone name if it is set for the currently running item.

Improvements to command output:

* [`cmd/tracking/status.go`](diffhunk://#diff-b5c57a469fd60bdbb91839b7ca7654d33295ebd281105c794a39da6ad5643708R55-R58): Updated the `StatusCmd` function to print the milestone name when it exists, improving visibility of milestone information in the status output.

## Screenshots

<!--
If this PR touches the visual layer of tmpo, please include screenshots or animated gifs to show the changes.
-->
