### PR TITLE
fix: Improve tilde expansion in export path handling

### DIFF
--- a/cmd/history/export.go
+++ b/cmd/history/export.go
@@ -92,10 +92,15 @@ func ExportCmd() *cobra.Command {
 			}
 
 			if exportPath != "" {
-				if exportPath[:1] == "~" {
+				if len(exportPath) >= 2 && exportPath[:2] == "~/" {
 					home, err := os.UserHomeDir()
 					if err == nil {
-						exportPath = filepath.Join(home, exportPath[1:])
+						exportPath = filepath.Join(home, exportPath[2:])
+					}
+				} else if exportPath == "~" {
+					home, err := os.UserHomeDir()
+					if err == nil {
+						exportPath = home
 					}
 				}
 


### PR DESCRIPTION
Refines logic to correctly expand both '~/...' and '~' to the user's home directory when specifying export paths.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #67

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request improves the handling of paths that use the tilde (`~`) to represent the user's home directory in the `ExportCmd` function. The update ensures that both `~/` (home directory with subpath) and `~` (home directory only) are correctly resolved.

Path handling improvements:

* Updated the logic to check for `~/` at the start of `exportPath` and replace it with the user's home directory, ensuring correct path resolution for subdirectories.
* Added a separate check for when `exportPath` is exactly `~`, setting it to the user's home directory.
