### PR TITLE
fix: Running `tmpo status` when milestone doesn't exist throws a segmentation fault

### DIFF
--- a/cmd/tracking/status.go
+++ b/cmd/tracking/status.go
@@ -52,7 +52,7 @@ func StatusCmd() *cobra.Command {
 				ui.PrintInfo(4, ui.Bold("Description"), running.Description)
 			}
 
-			if *running.MilestoneName != "" {
+			if running.MilestoneName != nil && *running.MilestoneName != "" {
 				ui.PrintInfo(4, ui.Bold("Milestone"), *running.MilestoneName);
 			}
 


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a minor fix to the `StatusCmd` function in `cmd/tracking/status.go` to prevent a potential nil pointer dereference when accessing `MilestoneName`.

- Added a check to ensure `running.MilestoneName` is not `nil` before dereferencing it in the milestone display logic in `StatusCmd` (`cmd/tracking/status.go`).