### PR TITLE
fix: Manual entries now correctly parse local time

### DIFF
--- a/cmd/entries/manual.go
+++ b/cmd/entries/manual.go
@@ -308,15 +308,15 @@ func parseDateTime(date, timeStr, dateLayout string) (time.Time, error) {
 	normalizedTime := normalizeAMPM(timeStr)
 	dateTime := fmt.Sprintf("%s %s", date, normalizedTime)
 
-	if dt, err := time.ParseInLocation(dateLayout + " 3:04 PM", dateTime, time.Local); err == nil {
+	if dt, err := time.ParseInLocation(dateLayout + " 3:04 PM", dateTime, settings.GetDisplayTimezone()); err == nil {
 		return dt, nil
 	}
 
-	if dt, err := time.ParseInLocation(dateLayout + " 03:04 PM", dateTime, time.Local); err == nil {
+	if dt, err := time.ParseInLocation(dateLayout + " 03:04 PM", dateTime, settings.GetDisplayTimezone()); err == nil {
 		return dt, nil
 	}
 
-	return time.ParseInLocation(dateLayout + " 15:04", dateTime, time.Local)
+	return time.ParseInLocation(dateLayout + " 15:04", dateTime, settings.GetDisplayTimezone())
 }
 
 func normalizeAMPM(input string) string {

--- a/internal/settings/global_config.go
+++ b/internal/settings/global_config.go
@@ -92,8 +92,8 @@ func (gc *GlobalConfig) Save() error {
 	return nil
 }
 
-// getDisplayTimezone returns the user's configured timezone or local timezone as fallback
-func getDisplayTimezone() *time.Location {
+// GetDisplayTimezone returns the user's configured timezone or local timezone as fallback
+func GetDisplayTimezone() *time.Location {
 	cfg, err := LoadGlobalConfig()
 	if err != nil || cfg.Timezone == "" {
 		return time.Local
@@ -109,7 +109,7 @@ func getDisplayTimezone() *time.Location {
 
 // toDisplayTime converts a UTC time to the user's display timezone
 func toDisplayTime(t time.Time) time.Time {
-	return t.In(getDisplayTimezone())
+	return t.In(GetDisplayTimezone())
 }
 
 func FormatTime(t time.Time) string {


### PR DESCRIPTION
Replaced usage of time.Local with settings.GetDisplayTimezone() in date parsing and display functions. Also exported GetDisplayTimezone for use outside the settings package, ensuring consistent timezone handling based on user configuration.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request updates how the application handles time zones by ensuring that all date and time parsing and formatting consistently use the user's configured display timezone instead of the local system timezone. The changes primarily involve switching from the local timezone to a configurable display timezone throughout the codebase.

**Timezone handling improvements:**

* Updated the `parseDateTime` function in `cmd/entries/manual.go` to use `settings.GetDisplayTimezone()` instead of `time.Local` for all date and time parsing, ensuring user-configured timezone is respected.
* Renamed and exported the `getDisplayTimezone` function to `GetDisplayTimezone` in `internal/settings/global_config.go` to make it accessible outside the package.
* Updated the `toDisplayTime` function to use the newly exported `GetDisplayTimezone` for converting UTC time to the user's display timezone.
