### PR TITLE
Check for version update only if current version is semver

### DIFF
--- a/cmd/utilities/version.go
+++ b/cmd/utilities/version.go
@@ -17,6 +17,8 @@ var (
 	Date    = "unknown"
 )
 
+var releaseVersionRegex = regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
+
 func VersionCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
@@ -54,8 +56,7 @@ func GetFormattedDate(inputDate string) string {
 func GetChangelogUrl(version string) string {
 	path := "https://github.com/DylanDevelops/tmpo"
 
-	r := regexp.MustCompile(`^v?\d+\.\d+\.\d+(-[\w.]+)?$`)
-	if !r.MatchString(version) {
+	if !isReleaseVersion(version) {
 		return fmt.Sprintf("%s/releases/latest", path)
 	}
 
@@ -63,8 +64,8 @@ func GetChangelogUrl(version string) string {
 }
 
 func checkForUpdates() {
-	// Only check if we have a valid version (not "dev" or empty)
-	if Version == "" || Version == "dev" {
+	// Only check for released semantic versions.
+	if !isReleaseVersion(Version) {
 		return
 	}
 
@@ -78,4 +79,8 @@ func checkForUpdates() {
 		fmt.Printf("%s %s\n", ui.Info("New Update Available:"), ui.Bold(strings.TrimPrefix(updateInfo.LatestVersion, "v")))
 		fmt.Printf("%s\n\n", ui.Muted(updateInfo.UpdateURL))
 	}
+}
+
+func isReleaseVersion(version string) bool {
+	return releaseVersionRegex.MatchString(version)
 }

--- a/cmd/utilities/version_test.go
+++ b/cmd/utilities/version_test.go
@@ -79,6 +79,11 @@ func TestGetChangelogUrl(t *testing.T) {
 			expected: "https://github.com/DylanDevelops/tmpo/releases/latest",
 		},
 		{
+			name:     "unstable version returns latest",
+			version:  "unstable",
+			expected: "https://github.com/DylanDevelops/tmpo/releases/latest",
+		},
+		{
 			name:     "empty version returns latest",
 			version:  "",
 			expected: "https://github.com/DylanDevelops/tmpo/releases/latest",


### PR DESCRIPTION
## Pull Request Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

## Description

Previously the function only checked for "dev" or empty for skipping the "update available" prompt. But more up-to-date builds might show something different. For instance, Nix builds would show "unstable". This PR make it so it only checks for newer version if current build is on a tagged semver release.
