### PR TITLE
fix: Avoid division by zero in stats percentage

### DIFF
--- a/cmd/history/stats.go
+++ b/cmd/history/stats.go
@@ -127,7 +127,12 @@ func ShowPeriodStats(entries []*storage.TimeEntry, periodName string) {
 
 	for _, project := range projects {
 		duration := projectStats[project]
-		percentage := (duration.Seconds() / totalDuration.Seconds()) * 100
+		percentage := 0.0
+
+		if totalDuration > 0 {
+			percentage = (duration.Seconds() / totalDuration.Seconds()) * 100
+		}
+
 		fmt.Printf("        %s  %s  (%.1f%%)\n", ui.Bold(fmt.Sprintf("%-20s", project)), ui.FormatDuration(duration), percentage)
 
 		if earnings, ok := projectEarnings[project]; ok && earnings > 0 {


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a small but important change to the calculation of project percentage statistics in the `ShowPeriodStats` function. The update ensures that division by zero is avoided when computing percentages.

* Added a conditional check to set `percentage` to 0.0 if `totalDuration` is zero, preventing potential division by zero errors in `stats.go`.