### PR TITLE
add: Allow empty start date to default to today in `tmpo manual`

### DIFF
--- a/cmd/entries/manual.go
+++ b/cmd/entries/manual.go
@@ -82,15 +82,29 @@ func ManualCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			todayDate := time.Now().Format(dateFormatLayout)
+
 			startDatePrompt := promptui.Prompt{
-				Label:    fmt.Sprintf("Start date (%s)", dateFormatDisplay),
-				Validate: func(input string) error { return validateDate(input, dateFormatLayout, dateFormatDisplay) },
+				Label:     fmt.Sprintf("Start date (%s): (%s)", dateFormatDisplay, todayDate),
+				AllowEdit: true,
+				Validate: func(input string) error {
+					if strings.TrimSpace(input) == "" {
+						return nil
+					}
+					
+					return validateDate(input, dateFormatLayout, dateFormatDisplay)
+				},
 			}
 
 			startDateInput, err := startDatePrompt.Run()
 			if err != nil {
 				ui.PrintError(ui.EmojiError, fmt.Sprintf("%v", err))
 				os.Exit(1)
+			}
+
+			startDateInput = strings.TrimSpace(startDateInput)
+			if startDateInput == "" {
+				startDateInput = todayDate
 			}
 
 			startTimePrompt := promptui.Prompt{


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #82

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request updates the manual entry command to improve the user experience when entering the start date. The changes make the start date prompt clearer and allow users to quickly accept today's date by pressing enter.

User experience improvements for date entry:

* The start date prompt now displays today's date as the default and allows users to edit the value or accept the default by pressing enter. If the input is left blank, today's date is automatically used. [[1]](diffhunk://#diff-e21132e0c6f46fa50f48c63ba574d5bf722a683b749f1027e9b5081c4f6b66cfR85-R96) [[2]](diffhunk://#diff-e21132e0c6f46fa50f48c63ba574d5bf722a683b749f1027e9b5081c4f6b66cfR105-R109)