### PR TITLE
fix: `tmpo log` doesn't always show all entries with `--today` and `--week` flags enabled

### DIFF
--- a/cmd/history/log.go
+++ b/cmd/history/log.go
@@ -63,8 +63,9 @@ func LogCmd() *cobra.Command {
 					weekday = 7 // sunday
 				}
 
-				start := now.AddDate(0, 0, -weekday+1).Truncate(24 * time.Hour).UTC()
-				end := start.AddDate(0, 0, 7)
+				startDay := now.AddDate(0, 0, -weekday+1)
+				start := time.Date(startDay.Year(), startDay.Month(), startDay.Day(), 0, 0, 0, 0, time.Local)
+				end := time.Now()
 				entries, err = db.GetEntriesByDateRange(start, end)
 			} else if logProject != "" {
 				entries, err = db.GetEntriesByProject(logProject)


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->
Closes #88

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request fixes an issue where `log --today` does not output all of the day's time entries for the user's local time.