### PR TITLE
feat: Add command auto-completion generation for brew formula

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -136,5 +136,6 @@ brews:
     skip_upload: false
     install: |
       bin.install "tmpo"
+      generate_completions_from_executable(bin/"tmpo", "completion")
     test: |
       system bin/"tmpo", "--version"


### PR DESCRIPTION
Update .goreleaser.yml to invoke generate_completions_from_executable in the brew install stanza so the Homebrew formula will generate shell completions from the tmpo executable on install. Existing install and test steps are preserved.

## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a small but useful enhancement to the Homebrew formula configuration by adding shell completions generation for the `tmpo` executable. This will improve the user experience by enabling command-line autocompletion for users who install via Homebrew.
