### PR TITLE
fix: Legacy Windows CMD formatting differently than other shells

### DIFF
--- a/cmd/utilities/version.go
+++ b/cmd/utilities/version.go
@@ -34,14 +34,15 @@ func VersionCmd() *cobra.Command {
 }
 
 func DisplayVersionWithUpdateCheck() {
-	fmt.Print(GetVersionOutput())
+	fmt.Println(GetVersionOutput())
 	checkForUpdates()
+	ui.NewlineBelow()
 }
 
 func GetVersionOutput() string {
 	versionLine := fmt.Sprintf("tmpo version %s %s", ui.Success(Version), ui.Muted(GetFormattedDate(Date)))
 	changelogLine := ui.Muted(GetChangelogUrl(Version))
-	return fmt.Sprintf("\n%s\n%s\n\n", versionLine, changelogLine)
+	return fmt.Sprintf("\n%s\n%s", versionLine, changelogLine)
 }
 
 func GetFormattedDate(inputDate string) string {
@@ -76,8 +77,8 @@ func checkForUpdates() {
 	}
 
 	if updateInfo.HasUpdate {
-		fmt.Printf("%s %s\n", ui.Info("New Update Available:"), ui.Bold(strings.TrimPrefix(updateInfo.LatestVersion, "v")))
-		fmt.Printf("%s\n\n", ui.Muted(updateInfo.UpdateURL))
+		fmt.Printf("\n%s %s\n", ui.Info("New Update Available:"), ui.Bold(strings.TrimPrefix(updateInfo.LatestVersion, "v")))
+		fmt.Printf("%s", ui.Muted(updateInfo.UpdateURL))
 	}
 }
 

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,0 +1,17 @@
+package shell
+
+import (
+	"os"
+	"runtime"
+)
+
+func IsLegacyWindowsCMD() bool {
+	if runtime.GOOS != "windows" {
+		return false
+	}
+
+	isCMD := os.Getenv("PROMPT") != ""
+	isUnixLike := os.Getenv("TERM") != ""
+
+	return isCMD && !isUnixLike
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,0 +1,60 @@
+package shell
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestIsLegacyWindowsCMD(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Run("returns false on non-Windows platforms", func(t *testing.T) {
+			result := IsLegacyWindowsCMD()
+			assert.False(t, result)
+		})
+		return
+	}
+
+	tests := []struct {
+		name     string
+		prompt   string
+		term     string
+		expected bool
+	}{
+		{
+			name:     "legacy CMD with PROMPT set and no TERM",
+			prompt:   "$P$G",
+			term:     "",
+			expected: true,
+		},
+		{
+			name:     "not CMD because PROMPT is not set",
+			prompt:   "",
+			term:     "",
+			expected: false,
+		},
+		{
+			name:     "Unix-like shell overrides PROMPT",
+			prompt:   "$P$G",
+			term:     "xterm-256color",
+			expected: false,
+		},
+		{
+			name:     "neither PROMPT nor TERM set",
+			prompt:   "",
+			term:     "xterm-256color",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("PROMPT", tt.prompt)
+			t.Setenv("TERM", tt.term)
+
+			result := IsLegacyWindowsCMD()
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/ui/ui.go
+++ b/internal/ui/ui.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"time"
+
+	"github.com/DylanDevelops/tmpo/internal/shell"
 )
 
 // ANSI Color Constants
@@ -141,7 +143,9 @@ func NewlineAbove() {
 }
 
 func NewlineBelow() {
-	fmt.Println()
+	if !shell.IsLegacyWindowsCMD() {
+		fmt.Println()
+	}
 }
 
 func FormatDuration(d time.Duration) string {


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #72

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request introduces a new utility for detecting legacy Windows CMD shells and updates the UI logic to improve compatibility with different terminal environments. It also includes minor enhancements to the version display output and its update check messaging.

**Shell detection and UI compatibility:**

* Added the `IsLegacyWindowsCMD` function in `internal/shell/shell.go` to detect if the application is running in a legacy Windows CMD shell, and comprehensive tests for this logic in `internal/shell/shell_test.go`. [[1]](diffhunk://#diff-fe91fa135e76b8b6e3c8e83dee0fa5f5b44c807a270c9a1982769eb1c5e0f130R1-R17) [[2]](diffhunk://#diff-b75ab7edfafe7e3ef45eb6373d3691a89b05e9b73f6c7f8c9d0a21480d86322cR1-R60)
* Updated `internal/ui/ui.go` to conditionally print a newline in `NewlineBelow()` only if not running in a legacy Windows CMD shell, improving output formatting on different platforms. [[1]](diffhunk://#diff-61d78c4a72f0cb72204ca681ae2493768f5bf1cb9850c8ec303ab672e4b20ed5R7-R8) [[2]](diffhunk://#diff-61d78c4a72f0cb72204ca681ae2493768f5bf1cb9850c8ec303ab672e4b20ed5R146-R149)

**Version command output improvements:**

* Changed `DisplayVersionWithUpdateCheck()` and `GetVersionOutput()` in `cmd/utilities/version.go` to refine the formatting of version and changelog output, and to more cleanly separate update checks from the main output.
* Improved the update notification formatting in `checkForUpdates()` to add spacing and remove redundant newlines, resulting in a cleaner display.

## Screenshots

<!--
If this PR touches the visual layer of tmpo, please include screenshots or animated gifs to show the changes.
-->
<img width="901" height="117" alt="image" src="https://github.com/user-attachments/assets/6ee5b660-941c-442c-afb7-2380221c2814" />