### PR TITLE
feat: Support --date flag for `tmpo log` and `tmpo stats`

### DIFF
--- a/cmd/history/log.go
+++ b/cmd/history/log.go
@@ -18,6 +18,7 @@ var (
 	logMilestone string
 	logToday     bool
 	logWeek      bool
+	logDate      string
 )
 
 func LogCmd() *cobra.Command {
@@ -51,6 +52,16 @@ func LogCmd() *cobra.Command {
 					projectName = detectedProject
 				}
 				entries, err = db.GetEntriesByMilestone(projectName, logMilestone)
+			} else if logDate != "" {
+				parsedDate, err := parseDateFlag(logDate)
+				if err != nil {
+					ui.PrintError(ui.EmojiError, err.Error())
+					ui.NewlineBelow()
+					os.Exit(1)
+				}
+				start := time.Date(parsedDate.Year(), parsedDate.Month(), parsedDate.Day(), 0, 0, 0, 0, time.Local)
+				end := start.Add(24 * time.Hour)
+				entries, err = db.GetEntriesByDateRange(start, end)
 			} else if logToday {
 				year, month, day := time.Now().Year(), time.Now().Month(), time.Now().Day()
 				start := time.Date(year, month, day, 0, 0, 0, 0, time.Local)
@@ -137,6 +148,40 @@ func LogCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&logMilestone, "milestone", "m", "", "Filter by milestone")
 	cmd.Flags().BoolVarP(&logToday, "today", "t", false, "Show today's entries")
 	cmd.Flags().BoolVarP(&logWeek, "week", "w", false, "Show this week's entries")
+	cmd.Flags().StringVarP(&logDate, "date", "d", "", "Show entries for a specific date")
 
 	return cmd
+}
+
+func parseDateFlag(dateStr string) (time.Time, error) {
+	globalCfg, err := settings.LoadGlobalConfig()
+	if err != nil {
+		return time.Time{}, fmt.Errorf("loading config: %w", err)
+	}
+
+	layout := "2006-01-02"
+	displayFormat := "YYYY-MM-DD"
+
+	switch globalCfg.DateFormat {
+	case "MM/DD/YYYY":
+		layout = "01-02-2006"
+		displayFormat = "MM-DD-YYYY"
+	case "DD/MM/YYYY":
+		layout = "02-01-2006"
+		displayFormat = "DD-MM-YYYY"
+	}
+
+	parsedDate, err := time.ParseInLocation(layout, dateStr, time.Local)
+	if err == nil {
+		return parsedDate, nil
+	}
+
+	if layout != "2006-01-02" {
+		parsedDate, err = time.ParseInLocation("2006-01-02", dateStr, time.Local)
+		if err == nil {
+			return parsedDate, nil
+		}
+	}
+
+	return time.Time{}, fmt.Errorf("invalid date format. Please use %s or YYYY-MM-DD", displayFormat)
 }

--- a/cmd/history/stats.go
+++ b/cmd/history/stats.go
@@ -16,6 +16,7 @@ import (
 var (
 	statsToday bool
 	statsWeek  bool
+	statsDate  string
 )
 
 func StatsCmd() *cobra.Command {
@@ -37,7 +38,17 @@ func StatsCmd() *cobra.Command {
 			var start, end time.Time
 			var periodName string
 
-			if statsToday {
+			if statsDate != "" {
+				parsedDate, err := parseDateFlag(statsDate)
+				if err != nil {
+					ui.PrintError(ui.EmojiError, err.Error())
+					ui.NewlineBelow()
+					os.Exit(1)
+				}
+				start = time.Date(parsedDate.Year(), parsedDate.Month(), parsedDate.Day(), 0, 0, 0, 0, parsedDate.Location()).UTC()
+				end = start.Add(24 * time.Hour)
+				periodName = parsedDate.Format("Jan 2, 2006")
+			} else if statsToday {
 				now := time.Now()
 				start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location()).UTC()
 				end = start.Add(24 * time.Hour)
@@ -75,6 +86,7 @@ func StatsCmd() *cobra.Command {
 
 	cmd.Flags().BoolVarP(&statsToday, "today", "t", false, "Show today's stats")
 	cmd.Flags().BoolVarP(&statsWeek, "week", "w", false, "Show this week's stats")
+	cmd.Flags().StringVarP(&statsDate, "date", "d", "", "Show stats for a specific date")
 
 	return cmd
 }


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #91

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request adds support for filtering history logs and statistics by a specific date in both the `log` and `stats` commands. It introduces a new `--date` (or `-d`) flag, allowing users to view entries or stats for a user-specified date. The implementation also includes logic to handle different date formats based on user configuration.

**New date filtering functionality:**

* Added a `--date` (`-d`) flag to both the `log` and `stats` commands to allow filtering entries or statistics for a specific date (`cmd/history/log.go`, `cmd/history/stats.go`). [[1]](diffhunk://#diff-f505bca0fafc8367cc26977dafe162565c73dab0ce00af4f6069192fcf7467fdR21) [[2]](diffhunk://#diff-3204a7025c953533e8c79d17194a7ce0d9f95a9b8448ac523520704bfbf04f8dR19) [[3]](diffhunk://#diff-f505bca0fafc8367cc26977dafe162565c73dab0ce00af4f6069192fcf7467fdR151-R187) [[4]](diffhunk://#diff-3204a7025c953533e8c79d17194a7ce0d9f95a9b8448ac523520704bfbf04f8dR89)

**Command logic updates:**

* Updated the `log` command to check for the `logDate` flag and retrieve entries within the specified date range using the new flag (`cmd/history/log.go`).
* Updated the `stats` command to check for the `statsDate` flag and compute statistics for the specified date, displaying the date in a user-friendly format (`cmd/history/stats.go`).

**Date parsing improvements:**

* Implemented a `parseDateFlag` helper function to parse the date input according to the user's configured date format, with fallback and error messaging (`cmd/history/log.go`).

These changes improve usability by allowing users to easily filter logs and stats by any date, not just today or this week.
