### PR TITLE
ci: Strip duplicate PR numbers and simplify mentions from changelog

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -5,8 +5,13 @@ body = """
 {% for group, commits in commits | group_by(attribute="group") %}
 ### {{ group | striptags | trim }}
 {% for commit in commits -%}
-- {% if commit.breaking %}[breaking] {% endif %}{{ commit.message | split(pat="\\n") | first | upper_first }}\
-{% if commit.remote.username %} by [@{{ commit.remote.username }}](https://github.com/{{ commit.remote.username }}){% endif %}\
+{% set commit_title = commit.message | split(pat="\\n") | first -%}
+{% if commit.remote.pr_number -%}
+    {% set pr_str = " (#" ~ commit.remote.pr_number ~ ")" -%}
+    {% set commit_title = commit_title | replace(from=pr_str, to="") -%}
+{% endif -%}
+- {% if commit.breaking %}[breaking] {% endif %}{{ commit_title | upper_first }}\
+{% if commit.remote.username %} by @{{ commit.remote.username }}{% endif %}\
 {% if commit.remote.pr_number %} in [#{{ commit.remote.pr_number }}](https://github.com/DylanDevelops/tmpo/pull/{{ commit.remote.pr_number }}){% endif %}
 {% endfor %}
 
@@ -15,7 +20,7 @@ body = """
 {% if new_contributors | length > 0 %}
 ## New Contributors
 {% for contributor in new_contributors -%}
-- [@{{ contributor.username }}](https://github.com/{{ contributor.username }}) made their first contribution!
+- @{{ contributor.username }} made their first contribution!
 {% endfor %}
 {% endif %}
 


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request updates the `cliff.toml` changelog template to improve the formatting and clarity of contributor and commit information. The main changes focus on simplifying the display of usernames and pull request references.

Changelog formatting improvements:

* Commit titles now have pull request numbers removed from the end if present, preventing duplication when the PR number is shown separately.
* Usernames are now displayed as plain text (e.g., `@username`) instead of markdown links, both in the commit attributions and the new contributors section. [[1]](diffhunk://#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584L8-R14) [[2]](diffhunk://#diff-e1372c8b03c40942b5d828a90975054cb8aaed3b38189f434396f922ec41a584L18-R23)
* The "New Contributors" section now lists contributors as `@username made their first contribution!` instead of linking their usernames.
