### PR TITLE
fix: Add newline after update URL in version check

### DIFF
--- a/cmd/utilities/version.go
+++ b/cmd/utilities/version.go
@@ -79,6 +79,7 @@ func checkForUpdates() {
 	if updateInfo.HasUpdate {
 		fmt.Printf("\n%s %s\n", ui.Info("New Update Available:"), ui.Bold(strings.TrimPrefix(updateInfo.LatestVersion, "v")))
 		fmt.Printf("%s", ui.Muted(updateInfo.UpdateURL))
+		ui.NewlineBelow()
 	}
 }
 


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a small improvement to the user interface in the `checkForUpdates` function by adding a blank line after displaying the update URL, enhancing readability.