### PR TITLE
fix: Autocompletions for Kiro CLI and other completion tools not showing

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,7 +109,6 @@ brews:
     homepage: "https://github.com/DylanDevelops/tmpo"
     description: "Minimal CLI time tracker for developers"
     license: "MIT"
-    extra_install: |
-      bash_completion.install "completions/tmpo.bash" => "tmpo"
-      zsh_completion.install "completions/tmpo.zsh" => "_tmpo"
-      fish_completion.install "completions/tmpo.fish"
+    install: |
+      bin.install "tmpo"
+      generate_completions_from_executable(bin/"tmpo", "completion")


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request updates the Homebrew formula configuration in `.goreleaser.yml` to simplify and standardize the installation process for shell completions.

**Homebrew formula improvements:**

* Replaces manual installation of shell completion scripts with the use of `generate_completions_from_executable`, which automatically generates completions from the `tmpo` executable.
* Moves the binary installation to the new `install` section, replacing the previous `extra_install` approach.