### PR TITLE
refactor: `tmpo log` now displays your time entries in chronological order

### DIFF
--- a/cmd/history/log.go
+++ b/cmd/history/log.go
@@ -3,6 +3,7 @@ package history
 import (
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/DylanDevelops/tmpo/internal/project"
@@ -101,7 +102,7 @@ func LogCmd() *cobra.Command {
 			var totalDuration time.Duration
 			currentDate := ""
 
-			for _, entry := range entries {
+			for _, entry := range slices.Backward(entries) {
 				entryDate := settings.FormatDateLong(entry.StartTime)
 				if entryDate != currentDate {
 					if currentDate != "" {


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request makes a small update to the `history` package by changing the order in which history log entries are processed. The entries are now iterated in reverse order by using `slices.Backward`, ensuring the most recent entries are handled first.

* Changed the log entry iteration in `cmd/history/log.go` to use `slices.Backward`, so entries are processed from newest to oldest.
* Added the `slices` package import in `cmd/history/log.go` to enable reverse iteration.
