### PR TITLE
refactor: Exported CSV and JSON files now list time entries in chronological order

### DIFF
--- a/internal/export/csv.go
+++ b/internal/export/csv.go
@@ -4,6 +4,7 @@ import (
 	"encoding/csv"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/DylanDevelops/tmpo/internal/settings"
@@ -27,7 +28,7 @@ func ToCSV(entries []*storage.TimeEntry, filename string, inUtc bool) error {
 		return fmt.Errorf("failed to write header: %w", err)
 	}
 
-	for _, entry := range entries {
+	for _, entry := range slices.Backward(entries) {
 		endTime := ""
 		if entry.EndTime != nil {
 			endTime = toCorrectCsvTimestamp(*entry.EndTime, inUtc)

--- a/internal/export/export_test.go
+++ b/internal/export/export_test.go
@@ -59,13 +59,20 @@ func TestToCSV(t *testing.T) {
 		// Verify header
 		assert.Equal(t, []string{"Project", "Start Time", "End Time", "Duration (hours)", "Description", "Milestone"}, records[0])
 
-		// Verify first entry
-		assert.Equal(t, "test-project", records[1][0])
+		// Verify entries are in chronological order
+		assert.Equal(t, "another-project", records[1][0])
 		assert.Equal(t, "2024-01-01 09:00:00", records[1][1])
 		assert.Equal(t, "2024-01-01 17:00:00", records[1][2])
-		assert.Equal(t, "8.00", records[1][3]) // 8 hours
-		assert.Equal(t, "Test work", records[1][4])
-		assert.Equal(t, "", records[1][5]) // No milestone
+		assert.Equal(t, "8.00", records[1][3])
+		assert.Equal(t, "More work", records[1][4])
+		assert.Equal(t, "", records[1][5])
+
+		assert.Equal(t, "test-project", records[2][0])
+		assert.Equal(t, "2024-01-01 09:00:00", records[2][1])
+		assert.Equal(t, "2024-01-01 17:00:00", records[2][2])
+		assert.Equal(t, "8.00", records[2][3])
+		assert.Equal(t, "Test work", records[2][4])
+		assert.Equal(t, "", records[2][5])
 	})
 
 	t.Run("handles running entries", func(t *testing.T) {
@@ -195,12 +202,18 @@ func TestToJson(t *testing.T) {
 		// Should have 2 entries
 		assert.Len(t, exportedEntries, 2)
 
-		// Verify first entry
-		assert.Equal(t, "test-project", exportedEntries[0].Project)
+		// Verify entries are in chronological order
+		assert.Equal(t, "another-project", exportedEntries[0].Project)
 		assert.Equal(t, "2024-01-01T09:00:00Z", exportedEntries[0].StartTime)
 		assert.Equal(t, "2024-01-01T17:00:00Z", exportedEntries[0].EndTime)
 		assert.Equal(t, 8.0, exportedEntries[0].Duration)
-		assert.Equal(t, "Test work", exportedEntries[0].Description)
+		assert.Equal(t, "More work", exportedEntries[0].Description)
+
+		assert.Equal(t, "test-project", exportedEntries[1].Project)
+		assert.Equal(t, "2024-01-01T09:00:00Z", exportedEntries[1].StartTime)
+		assert.Equal(t, "2024-01-01T17:00:00Z", exportedEntries[1].EndTime)
+		assert.Equal(t, 8.0, exportedEntries[1].Duration)
+		assert.Equal(t, "Test work", exportedEntries[1].Description)
 	})
 
 	t.Run("handles running entries", func(t *testing.T) {

--- a/internal/export/json.go
+++ b/internal/export/json.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"slices"
 	"time"
 
 	"github.com/DylanDevelops/tmpo/internal/settings"
@@ -22,7 +23,7 @@ type ExportEntry struct {
 func ToJson(entries []*storage.TimeEntry, filename string, inUtc bool) error {
 	var exportEntries []ExportEntry
 
-	for _, entry := range entries {
+	for _, entry := range slices.Backward(entries) {
 		export := ExportEntry{
 			Project:     entry.ProjectName,
 			StartTime:   toCorrectJsonTimestamp(entry.StartTime, inUtc),


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request updates the export functionality to ensure that exported time entries are written in chronological order (oldest first) for both CSV and JSON exports. The changes also update the corresponding tests to verify this new ordering.

**Export order improvements:**
* Updated both `ToCSV` in `internal/export/csv.go` and `ToJson` in `internal/export/json.go` to iterate over entries in chronological order using `slices.Backward`, ensuring exported data is ordered from oldest to newest. [[1]](diffhunk://#diff-00bca05f586937c590d1f5f7a20934ce2818c6bbfba367c1723a9f954e9e6f86R7) [[2]](diffhunk://#diff-00bca05f586937c590d1f5f7a20934ce2818c6bbfba367c1723a9f954e9e6f86L30-R31) [[3]](diffhunk://#diff-6562d986654efcdcb03aec3d34d72e7a7da0f9c0735a053a6132f24221c5e051R7) [[4]](diffhunk://#diff-6562d986654efcdcb03aec3d34d72e7a7da0f9c0735a053a6132f24221c5e051L25-R26)

**Test updates:**
* Modified tests in `internal/export/export_test.go` to assert that exported entries are in chronological order for both CSV and JSON exports, updating expected values accordingly. [[1]](diffhunk://#diff-24c524651ba2f96e57daf9e3055a2881d7e6b05858481eb5628b6ba78d4c52bcL62-R75) [[2]](diffhunk://#diff-24c524651ba2f96e57daf9e3055a2881d7e6b05858481eb5628b6ba78d4c52bcL198-R216)
