### PR TITLE
refactor: `tmpo backup list` now displays backups in chronological order

### DIFF
--- a/cmd/backups/list.go
+++ b/cmd/backups/list.go
@@ -36,7 +36,7 @@ func ListCmd() *cobra.Command {
 				ui.FormatBold, "ID", "Created", "Size", "Schema", ui.ColorReset)
 			fmt.Println()
 
-			for _, b := range backups {
+			for i, b := range backups {
 				var schemaTag string
 				if b.IsUpToDate {
 					schemaTag = fmt.Sprintf("%s%s v%d (current)%s", ui.ColorGreen, ui.EmojiSuccess, b.SchemaVersion, ui.ColorReset)
@@ -44,11 +44,17 @@ func ListCmd() *cobra.Command {
 					schemaTag = fmt.Sprintf("%s%s v%d (outdated)%s", ui.ColorYellow, ui.EmojiWarning, b.SchemaVersion, ui.ColorReset)
 				}
 
-				fmt.Printf("  %-4d  %-28s  %-8s  %s\n",
+				var latestTag string
+				if i == len(backups)-1 {
+					latestTag = fmt.Sprintf("  %s← latest%s", ui.ColorCyan, ui.ColorReset)
+				}
+
+				fmt.Printf("  %-4d  %-28s  %-8s  %s%s\n",
 					b.ID,
 					settings.FormatDateTime(b.CreatedAt),
 					ui.FormatFileSize(b.Size),
 					schemaTag,
+					latestTag,
 				)
 			}
 

--- a/internal/storage/backup.go
+++ b/internal/storage/backup.go
@@ -75,7 +75,7 @@ func (d *Database) CreateBackup() (*BackupInfo, error) {
 	}, nil
 }
 
-// ListBackups returns all backups sorted newest-first with display IDs assigned (1 = newest).
+// ListBackups returns all backups sorted oldest-first with display IDs assigned (1 = oldest).
 func ListBackups() ([]BackupInfo, error) {
 	backupDir, err := GetBackupDir()
 	if err != nil {
@@ -118,7 +118,7 @@ func ListBackups() ([]BackupInfo, error) {
 	}
 
 	sort.Slice(backups, func(i, j int) bool {
-		return backups[i].CreatedAt.After(backups[j].CreatedAt)
+		return backups[i].CreatedAt.Before(backups[j].CreatedAt)
 	})
 
 	for i := range backups {

--- a/internal/storage/backup_test.go
+++ b/internal/storage/backup_test.go
@@ -163,7 +163,7 @@ func TestListBackups_IgnoresNonDBFiles(t *testing.T) {
 	assert.Empty(t, backups)
 }
 
-func TestListBackups_SortedNewestFirst(t *testing.T) {
+func TestListBackups_SortedOldestFirst(t *testing.T) {
 	tmpHome := t.TempDir()
 	t.Setenv("HOME", tmpHome)
 	t.Setenv("USERPROFILE", tmpHome)
@@ -190,9 +190,9 @@ func TestListBackups_SortedNewestFirst(t *testing.T) {
 
 	assert.Equal(t, 1, backups[0].ID)
 	assert.Equal(t, 2, backups[1].ID)
-	assert.Equal(t, "tmpo-20260102-100000.db", backups[0].Filename)
-	assert.Equal(t, "tmpo-20260101-100000.db", backups[1].Filename)
-	assert.True(t, backups[0].CreatedAt.After(backups[1].CreatedAt))
+	assert.Equal(t, "tmpo-20260101-100000.db", backups[0].Filename)
+	assert.Equal(t, "tmpo-20260102-100000.db", backups[1].Filename)
+	assert.True(t, backups[0].CreatedAt.Before(backups[1].CreatedAt))
 }
 
 func TestCreateBackup(t *testing.T) {


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

This pull request updates the backup listing functionality to sort and display backups in oldest-to-newest order (instead of newest-to-oldest), and updates the CLI output to clearly indicate the latest backup. The test suite and documentation are also updated to match this new behavior.

**Backup ordering and display changes:**

* Changed the `ListBackups` function in `internal/storage/backup.go` to return backups sorted oldest-first (1 = oldest), instead of newest-first. This includes updating the sorting logic and the function's documentation comment. [[1]](diffhunk://#diff-c5f4a473bfeea14e7d1086e7d52f98f60b4ceb48ca7b2efc4ed6ba8b0190666fL78-R78) [[2]](diffhunk://#diff-c5f4a473bfeea14e7d1086e7d52f98f60b4ceb48ca7b2efc4ed6ba8b0190666fL121-R121)
* Updated the CLI output in `cmd/backups/list.go` to add a "← latest" tag next to the most recent (latest) backup, making it clear to users which backup is the newest.

**Test and documentation updates:**

* Renamed and updated the test `TestListBackups_SortedNewestFirst` to `TestListBackups_SortedOldestFirst` in `internal/storage/backup_test.go`, and adjusted assertions to expect oldest-first order. [[1]](diffhunk://#diff-67f083c319326c3cba40985079afb17a56b49072f2e8ce85f23225ace98e28feL166-R166) [[2]](diffhunk://#diff-67f083c319326c3cba40985079afb17a56b49072f2e8ce85f23225ace98e28feL193-R195)