### PR TITLE
feat: `tmpo undo` now covers `tmpo edit` command usage

### DIFF
--- a/cmd/entries/edit.go
+++ b/cmd/entries/edit.go
@@ -433,6 +433,13 @@ func EditCmd() *cobra.Command {
 				os.Exit(1)
 			}
 
+			db.SaveLastAction(storage.UndoAction{
+				Type:        storage.ActionEdit,
+				EntryID:     selectedEntry.ID,
+				ProjectName: selectedEntry.ProjectName,
+				Entry:       selectedEntry,
+			})
+
 			fmt.Println()
 			ui.PrintSuccess(ui.EmojiSuccess, "Entry updated successfully")
 			ui.NewlineBelow()

--- a/cmd/utilities/undo.go
+++ b/cmd/utilities/undo.go
@@ -17,6 +17,7 @@ var actionDescriptions = map[storage.ActionType]string{
 	storage.ActionResume: "Resumed tracking",
 	storage.ActionManual: "Created manual entry for",
 	storage.ActionDelete: "Deleted entry for",
+	storage.ActionEdit:   "Edited entry for",
 }
 
 func UndoCmd() *cobra.Command {
@@ -103,6 +104,12 @@ func applyUndo(db *storage.Database, action *storage.UndoAction) error {
 			return fmt.Errorf("no entry snapshot available to restore")
 		}
 		return db.RestoreDeletedEntry(action.Entry)
+
+	case storage.ActionEdit:
+		if action.Entry == nil {
+			return fmt.Errorf("no entry snapshot available to restore")
+		}
+		return db.UpdateTimeEntry(action.EntryID, action.Entry)
 
 	default:
 		return fmt.Errorf("unknown action type: %s", action.Type)

--- a/cmd/utilities/undo_test.go
+++ b/cmd/utilities/undo_test.go
@@ -2,6 +2,7 @@ package utilities
 
 import (
 	"testing"
+	"time"
 
 	"github.com/DylanDevelops/tmpo/internal/storage"
 	"github.com/stretchr/testify/assert"
@@ -31,6 +32,7 @@ func TestUndoActionDescription(t *testing.T) {
 		{storage.ActionResume, "Resumed tracking"},
 		{storage.ActionManual, "Created manual entry for"},
 		{storage.ActionDelete, "Deleted entry for"},
+		{storage.ActionEdit, "Edited entry for"},
 	}
 
 	for _, tt := range tests {
@@ -89,6 +91,47 @@ func TestApplyUndo_Delete_ErrorWhenNoSnapshot(t *testing.T) {
 	err := applyUndo(db, action)
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "no entry snapshot")
+}
+
+func TestApplyUndo_Edit_ErrorWhenNoSnapshot(t *testing.T) {
+	db := setupUndoTestDB(t)
+
+	action := &storage.UndoAction{Type: storage.ActionEdit, ProjectName: "proj", Entry: nil}
+	err := applyUndo(db, action)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "no entry snapshot")
+}
+
+func TestApplyUndo_Edit_RestoresOriginalEntry(t *testing.T) {
+	db := setupUndoTestDB(t)
+
+	// Create and stop an entry, then capture its pre-edit snapshot.
+	orig, err := db.CreateEntry("proj", "before", nil, nil)
+	require.NoError(t, err)
+	require.NoError(t, db.StopEntry(orig.ID))
+
+	before, err := db.GetEntry(orig.ID)
+	require.NoError(t, err)
+
+	// Apply an edit that changes several fields.
+	edited := *before
+	newStart := before.StartTime.Add(-time.Hour)
+	newEnd := before.EndTime.Add(time.Hour)
+	edited.StartTime = newStart
+	edited.EndTime = &newEnd
+	edited.Description = "after"
+	require.NoError(t, db.UpdateTimeEntry(edited.ID, &edited))
+
+	// Undo should restore the original values.
+	action := &storage.UndoAction{Type: storage.ActionEdit, EntryID: before.ID, ProjectName: "proj", Entry: before}
+	require.NoError(t, applyUndo(db, action))
+
+	restored, err := db.GetEntry(orig.ID)
+	require.NoError(t, err)
+	assert.Equal(t, "before", restored.Description)
+	assert.True(t, restored.StartTime.Equal(before.StartTime), "start time should be restored")
+	require.NotNil(t, restored.EndTime)
+	assert.True(t, restored.EndTime.Equal(*before.EndTime), "end time should be restored")
 }
 
 func TestApplyUndo_UnknownType_ReturnsError(t *testing.T) {

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -433,14 +433,15 @@ Revert the most recent time-tracking action in case of a mistake. A single confi
 
 **Supported actions:**
 
-| Action        | What undo does                                    |
-|---------------|---------------------------------------------------|
-| `tmpo start`  | Deletes the entry that was just created           |
-| `tmpo stop`   | Re-opens the stopped entry as a running timer     |
-| `tmpo pause`  | Re-opens the paused entry as a running timer      |
-| `tmpo resume` | Deletes the new entry that was created to resume  |
-| `tmpo manual` | Deletes the manually created entry                |
-| `tmpo delete` | Restores the deleted entry with its original data |
+| Action        | What undo does                                         |
+|---------------|--------------------------------------------------------|
+| `tmpo start`  | Deletes the entry that was just created                |
+| `tmpo stop`   | Re-opens the stopped entry as a running timer          |
+| `tmpo pause`  | Re-opens the paused entry as a running timer           |
+| `tmpo resume` | Deletes the new entry that was created to resume       |
+| `tmpo manual` | Deletes the manually created entry                     |
+| `tmpo delete` | Restores the deleted entry with its original data      |
+| `tmpo edit`   | Restores the previous version of the edited time entry |
 
 **Examples:**
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -433,15 +433,15 @@ Revert the most recent time-tracking action in case of a mistake. A single confi
 
 **Supported actions:**
 
-| Action        | What undo does                                         |
-|---------------|--------------------------------------------------------|
-| `tmpo start`  | Deletes the entry that was just created                |
-| `tmpo stop`   | Re-opens the stopped entry as a running timer          |
-| `tmpo pause`  | Re-opens the paused entry as a running timer           |
-| `tmpo resume` | Deletes the new entry that was created to resume       |
-| `tmpo manual` | Deletes the manually created entry                     |
-| `tmpo delete` | Restores the deleted entry with its original data      |
-| `tmpo edit`   | Restores the previous version of the edited time entry |
+| Action        | What undo does                                        |
+|---------------|-------------------------------------------------------|
+| `tmpo start`  | Deletes the entry that was just created               |
+| `tmpo stop`   | Re-opens the stopped entry as a running timer         |
+| `tmpo pause`  | Re-opens the paused entry as a running timer          |
+| `tmpo resume` | Deletes the new entry that was created to resume      |
+| `tmpo manual` | Deletes the manually created entry                    |
+| `tmpo delete` | Restores the deleted entry with its original data     |
+| `tmpo edit`   | Restores the previous version of an edited time entry |
 
 **Examples:**
 

--- a/internal/storage/undo.go
+++ b/internal/storage/undo.go
@@ -16,6 +16,7 @@ const (
 	ActionResume ActionType = "resume"
 	ActionDelete ActionType = "delete"
 	ActionManual ActionType = "manual"
+	ActionEdit   ActionType = "edit"
 )
 
 const lastActionKey = "last_action"


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #136

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

- `tmpo edit` now takes a snapshot of db to be used when `tmpo undo` is run
- Updated docs to reflect new feature
