### PR TITLE
fix: `tmpo export [--today | --week]` now uses configured timezone

### DIFF
--- a/cmd/history/export.go
+++ b/cmd/history/export.go
@@ -62,7 +62,7 @@ func ExportCmd() *cobra.Command {
 
 				now := time.Now().In(tz)
 				start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, tz)
-				end := start.Add(24 * time.Hour)
+				end := start.AddDate(0, 0, 1)
 
 				entries, err = db.GetEntriesByDateRange(start, end)
 			} else if exportWeek {

--- a/cmd/history/export.go
+++ b/cmd/history/export.go
@@ -55,18 +55,37 @@ func ExportCmd() *cobra.Command {
 				}
 				entries, err = db.GetEntriesByMilestone(projectName, exportMilestone)
 			} else if exportToday {
-				start := time.Now().Truncate(24 * time.Hour)
+				tz := settings.GetDisplayTimezone()
+				if exportUtc {
+					tz = time.UTC
+				}
+
+				now := time.Now().In(tz)
+				start := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, tz)
 				end := start.Add(24 * time.Hour)
+
 				entries, err = db.GetEntriesByDateRange(start, end)
 			} else if exportWeek {
-				now := time.Now()
+				tz := settings.GetDisplayTimezone()
+				if exportUtc {
+					tz = time.UTC
+				}
+
+				now := time.Now().In(tz)
 				weekday := int(now.Weekday())
 				if weekday == 0 {
 					weekday = 7 // sunday
 				}
 
-				start := now.AddDate(0, 0, -weekday+1).Truncate(24 * time.Hour)
+				firstOfWeek := now.AddDate(0, 0, -weekday+1)
+				start := time.Date(
+					firstOfWeek.Year(),
+					firstOfWeek.Month(),
+					firstOfWeek.Day(),
+					0, 0, 0, 0,
+					tz)
 				end := start.AddDate(0, 0, 7)
+
 				entries, err = db.GetEntriesByDateRange(start, end)
 			} else if exportProject != "" {
 				entries, err = db.GetEntriesByProject(exportProject)


### PR DESCRIPTION
## Pull Request Checklist

<!--
Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously.
-->

- [x] I have read and followed the [contribution guidelines](https://github.com/DylanDevelops/tmpo/blob/main/CONTRIBUTING.md).
- [x] My pull request targets the `main` branch of tmpo.
- [x] I have tested these changes locally on my machine.

<!--
What tmpo issue does this PR address (for example, #1234)?
If you have not created an issue for your PR, please search the issue tracker to see if there is an existing issue that aligns with your PR, or open a new issue for discussion.
-->

Closes #133

## Description

<!--
A summary of the changes made along with any other information that would be helpful to a reviewer such as potential tradeoffs or alternative approaches you considered.
-->

Fixed a bug where exporting with the `--today` or `--week` flag would not use the configured timezone. To export using the UTC timezone, you must pass in the `--utc` flag.